### PR TITLE
Handle SQLite directory creation before initialization

### DIFF
--- a/src/persistence/database.js
+++ b/src/persistence/database.js
@@ -1,5 +1,5 @@
 import Database from 'better-sqlite3';
-import { readdirSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { inferMigrationVersion, seedAll } from './seeds.js';
@@ -16,7 +16,22 @@ const DEFAULT_DB = (() => {
   }
 })();
 
+function ensureDirectoryFor(filename) {
+  if (!filename || filename === ':memory:' || filename.startsWith('file:')) {
+    return;
+  }
+
+  const directory = dirname(filename);
+
+  if (!directory || directory === '.' || existsSync(directory)) {
+    return;
+  }
+
+  mkdirSync(directory, { recursive: true });
+}
+
 export function openDatabase({ filename = DEFAULT_DB } = {}) {
+  ensureDirectoryFor(filename);
   const db = new Database(filename, { verbose: undefined });
   db.pragma('journal_mode = WAL');
   db.pragma('foreign_keys = ON');

--- a/test/persistence.databasePath.test.js
+++ b/test/persistence.databasePath.test.js
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { initializeDatabase } from '../src/persistence/database.js';
+
+const TMP_PREFIX = join(tmpdir(), 'agi-alpha-db-');
+
+describe('database file initialization', () => {
+  let tempRoot;
+
+  afterEach(() => {
+    if (tempRoot) {
+      rmSync(tempRoot, { recursive: true, force: true });
+      tempRoot = undefined;
+    }
+  });
+
+  it('creates parent directories for sqlite file targets', () => {
+    tempRoot = mkdtempSync(TMP_PREFIX);
+    const nestedPath = join(tempRoot, 'nested', 'paths', 'db.sqlite');
+
+    expect(existsSync(join(tempRoot, 'nested', 'paths'))).toBe(false);
+
+    const db = initializeDatabase({ filename: nestedPath });
+    db.close();
+
+    expect(existsSync(nestedPath)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure SQLite database parents are created automatically before opening the file
- add regression coverage for initializing databases in nested directories

## Testing
- node scripts/vitest-runner.mjs run test/persistence.databasePath.test.js --passWithNoTests=false
- npm test
- npm run test:frontend

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693044d775688333a694676d14f1003b)